### PR TITLE
Fixes bug that if only backlist is supplied incorrectly getting 403 error

### DIFF
--- a/src/Firewall.php
+++ b/src/Firewall.php
@@ -77,6 +77,8 @@ class Firewall implements MiddlewareInterface
 
         if (!empty($this->whitelist)) {
             $firewall->addList($this->whitelist, 'whitelist', true);
+        } else {
+            $firewall->setDefaultState(true);
         }
 
         if (!empty($this->blacklist)) {


### PR DESCRIPTION
If this middleware is used without whitelist and only with backlist is supplied, it incorrectly things that not blacklisted IPs are bad. 

F.e.:
```php
Dispatcher::run([
    (new Middlewares\Firewall(null))
        ->blacklist([
            '123.0.0.1',
            '123.0.0.2',
        ])
]);
```
Incorrectly thinks that if user comes from IP `127.0.0.1` that with such IP is something wrong. 

It seems for this case changing IpFirewall default state value helps because in that case IP validation works with rule not `$whited && !$blacked` but with `!$blacked || $whited`. And that is what we need for this case.