### PR TITLE
Replace abandoned m6web/firewall with mlocati/ip-lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Testing][ico-ga]
 [![Total Downloads][ico-downloads]][link-downloads]
 
-Middleware to provide IP filtering using [M6Web/Firewall](https://github.com/M6Web/Firewall).
+Middleware to provide IP filtering.
 
 ## Requirements
 

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     },
     "require": {
         "php": "^7.2 || ^8.0",
-        "m6web/firewall": "^1.0",
         "middlewares/utils": "^3.0",
-        "psr/http-server-middleware": "^1.0"
+        "psr/http-server-middleware": "^1.0",
+        "mlocati/ip-lib": "^1.18"
     },
     "require-dev": {
         "phpunit/phpunit": "^8|^9",

--- a/src/Firewall.php
+++ b/src/Firewall.php
@@ -5,7 +5,6 @@ namespace Middlewares;
 
 use IPLib\Address\AddressInterface;
 use IPLib\Factory as IPFactory;
-use IPLib\Range\Pattern;
 use IPLib\Range\RangeInterface;
 use Middlewares\Utils\Factory;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -104,7 +103,8 @@ class Firewall implements MiddlewareInterface
      *
      * @return RangeInterface
      */
-    protected function createRangeInstance(string $range): RangeInterface {
+    protected function createRangeInstance(string $range): RangeInterface
+    {
         if (strpos($range, '-') !== false) {
             $parts = explode('-', $range, 2);
             return IPFactory::getRangesFromBoundaries($parts[0], $parts[1]);
@@ -136,11 +136,12 @@ class Firewall implements MiddlewareInterface
      * Checks if IP address is in list
      *
      * @param AddressInterface $address IP address to check
-     * @param array $list List of addresses to check
+     * @param array            $list    List of addresses to check
      *
      * @return bool
      */
-    private function isAddressInList(AddressInterface $address, array $list): bool {
+    private function isAddressInList(AddressInterface $address, array $list): bool
+    {
         /**
          * @var RangeInterface $ipRange
          */
@@ -179,6 +180,7 @@ class Firewall implements MiddlewareInterface
             return !$this->isAddressInList($address, $this->blacklist);
         }
 
-        return $this->isAddressInList($address, $this->whitelist) && !$this->isAddressInList($address, $this->blacklist);
+        return $this->isAddressInList($address, $this->whitelist) &&
+               !$this->isAddressInList($address, $this->blacklist);
     }
 }


### PR DESCRIPTION
As the title says. [m6web/firewall](https://packagist.org/packages/m6web/firewall) is abandoned, so it was replaced with [mlocati/ip-lib](https://github.com/mlocati/ip-lib). 

It's not really equal replacement so some extra code there for that also was needed.

Fixes #4 