### PR TITLE
Allow middlewares/utils to use version 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": "^7.2 || ^8.0",
-        "middlewares/utils": "^3.0",
+        "middlewares/utils": "^3.0" || "^4.0",
         "psr/http-server-middleware": "^1.0",
         "mlocati/ip-lib": "^1.18"
     },


### PR DESCRIPTION
This package only allows for version 3 of `middlewares/utils` when several other middlewares ([negotiation](https://github.com/middlewares/negotiation/blob/master/composer.json#L24), [payload](https://github.com/middlewares/payload/blob/master/composer.json#L22))  allow composer to select either version 3 or version 4.  This brings firewall into line with the others.